### PR TITLE
Fix for issue #29 (timer roll-over displaying 58:47)

### DIFF
--- a/src/motorControl.cpp
+++ b/src/motorControl.cpp
@@ -283,7 +283,10 @@ unsigned long MotorControl::getSecondsRemaining() {
 
     unsigned long rtn = 0;
     if (state.isRunning) {
-        rtn = (state.run_end - millis()) / 1000;
+            if(state.run_end > millis()) // Need to stop 'negative' result 
+                rtn = ((state.run_end - millis()) / 1000);
+            else
+                rtn = 0;
     }
 
     return rtn;


### PR DESCRIPTION
The problem was in the getsecondsRemaining() method in motorControl.cpp.

When the countdown reached zero, by the time the method was called, millis would be greater than state.run_end so the calculation 'state.run_end-millis()'  would produce a negative result that the unsigned int cannot handle. This resulted in a large positive integer 